### PR TITLE
[Enhancement]: Add simple arrow tags to network traffic to avoid confusion.

### DIFF
--- a/components/ServerCardPopover.tsx
+++ b/components/ServerCardPopover.tsx
@@ -57,7 +57,7 @@ export default function ServerCardPopover({
       />
       <ServerCardPopoverCard
         title={t("Network")}
-        content={`${formatBytes(status.NetOutTransfer)} / ${formatBytes(status.NetInTransfer)}`}
+        content={`↑ ${formatBytes(status.NetOutTransfer)} / ↓ ${formatBytes(status.NetInTransfer)}`}
       />
       <ServerCardPopoverCard
         title={t("Load")}


### PR DESCRIPTION
In contents of network details, data like 25.38 GiB / 18.5 GiB does not clearly indicate the specific direction of traffic. A simple arrow has been added for easier reading. if there are better visualization solutions, let's hear them!

在网络详细信息的显示上，类似  25.38 GiB / 18.5 GiB 这样的数据无法辨识出流量的具体方向, 增加了一个简单的箭头提示方便阅读，如果有更好的可视化方案欢迎讨论。

See the image below.
添加后的效果见下图

![截图_20241019130514](https://github.com/user-attachments/assets/5bb58f52-f7fe-447c-ac01-6055a09bc99d)
