### PR TITLE
feat: add boot time display to server details and update localization

### DIFF
--- a/app/(main)/ClientComponents/detail/ServerDetailClient.tsx
+++ b/app/(main)/ClientComponents/detail/ServerDetailClient.tsx
@@ -83,6 +83,7 @@ export default function ServerDetailClient({
     net_out_transfer,
     net_in_transfer,
     last_active_time_string,
+    boot_time_string,
   } = formatNezhaInfo(serverData)
 
   return (
@@ -251,6 +252,14 @@ export default function ServerDetailClient({
         </Card>
       </section>
       <section className="mt-1 flex flex-wrap gap-2">
+        <Card className="rounded-[10px] border-none bg-transparent shadow-none">
+          <CardContent className="px-1.5 py-1">
+            <section className="flex flex-col items-start gap-0.5">
+              <p className="text-muted-foreground text-xs">{t("BootTime")}</p>
+              <div className="text-xs">{boot_time_string ? boot_time_string : "N/A"}</div>
+            </section>
+          </CardContent>
+        </Card>
         <Card className="rounded-[10px] border-none bg-transparent shadow-none">
           <CardContent className="px-1.5 py-1">
             <section className="flex flex-col items-start gap-0.5">

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,6 +16,10 @@ export function formatNezhaInfo(serverInfo: NezhaAPISafe) {
     last_active_time_string: serverInfo.last_active
       ? new Date(serverInfo.last_active * 1000).toLocaleString()
       : "",
+    boot_time: serverInfo.host.BootTime,
+    boot_time_string: serverInfo.host.BootTime
+      ? new Date(serverInfo.host.BootTime * 1000).toLocaleString()
+      : "",
     online: serverInfo.online_status,
     uptime: serverInfo.status.Uptime || 0,
     version: serverInfo.host.Version || null,

--- a/messages/en.json
+++ b/messages/en.json
@@ -86,7 +86,8 @@
     "Upload": "Upload",
     "Download": "Download",
     "Load": "Load",
-    "LastActive": "Last Active"
+    "LastActive": "Last Active",
+    "BootTime": "Boot Time"
   },
   "ServerDetailChartClient": {
     "chart_fetch_error_message": "Please check your environment variables and review the server console",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -86,7 +86,8 @@
     "Load": "負荷",
     "Upload": "Upload",
     "Download": "Download",
-    "LastActive": "Last Active"
+    "LastActive": "Last Active",
+    "BootTime": "Boot Time"
   },
   "ServerDetailChartClient": {
     "chart_fetch_error_message": "環境変数を確認し、サーバーコンソールを確認してください",

--- a/messages/zh-t.json
+++ b/messages/zh-t.json
@@ -86,7 +86,8 @@
     "Upload": "上傳",
     "Download": "下載",
     "Load": "負載",
-    "LastActive": "最後上報時間"
+    "LastActive": "最後上報時間",
+    "BootTime": "啟動時間"
   },
   "ServerDetailChartClient": {
     "chart_fetch_error_message": "獲取伺服器詳情失敗,請檢查您的環境變數並檢查伺服器控制台",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -86,7 +86,8 @@
     "Upload": "上传",
     "Download": "下载",
     "Load": "负载",
-    "LastActive": "最后上报时间"
+    "LastActive": "最后上报时间",
+    "BootTime": "启动时间"
   },
   "ServerDetailChartClient": {
     "chart_fetch_error_message": "获取服务器详情失败，请检查您的环境变量并检查服务器控制台",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The server details view now includes a dedicated card displaying the server’s boot time, showing either a formatted boot time or "N/A" if unavailable.
  - Enhanced localization of boot time information, with updated labels available in English, Japanese, Chinese (Traditional), and Chinese (Simplified).

- **Style**
  - Improved wording consistency in the UI text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->