### PR TITLE
Potential fix for code scanning alert no. 13: Use of password hash with insufficient computational effort

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -1,17 +1,16 @@
-import { createHash, timingSafeEqual } from "node:crypto"
+import { timingSafeEqual } from "node:crypto"
 import NextAuth from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
 import getEnv from "@/lib/env-entry"
 
 function safeEqual(a: string, b: string): boolean {
   try {
-    const bufA = Buffer.isBuffer(a) ? a : Buffer.from(a)
-    const bufB = Buffer.isBuffer(b) ? b : Buffer.from(b)
+    const bufA = Buffer.from(a)
+    const bufB = Buffer.from(b)
 
-    const hashA = createHash("sha256").update(bufA).digest()
-    const hashB = createHash("sha256").update(bufB).digest()
+    if (bufA.length !== bufB.length) return false
 
-    return timingSafeEqual(hashA, hashB)
+    return timingSafeEqual(bufA, bufB)
   } catch (_err) {
     return false
   }

--- a/auth.ts
+++ b/auth.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto"
+import { createHash, timingSafeEqual } from "node:crypto"
 import NextAuth from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
 import getEnv from "@/lib/env-entry"


### PR DESCRIPTION
Potential fix for [https://github.com/hamster1963/nezha-dash/security/code-scanning/13](https://github.com/hamster1963/nezha-dash/security/code-scanning/13)

General fix: avoid hashing password values with fast hash functions (`sha256`) in authentication logic. For constant-time comparison, compare byte buffers directly with `timingSafeEqual` after enforcing equal length.

Best fix in `auth.ts`:
- Update `safeEqual` so it:
  1. Converts both strings to `Buffer`.
  2. Returns `false` immediately if lengths differ.
  3. Calls `timingSafeEqual(bufA, bufB)` directly.
- Remove unused `createHash` import since hashing is no longer needed there.
- Keep all existing auth flow and functionality unchanged (`authorize`, `sitePassword`, return values).

This addresses all alert variants at the same sink location by removing insecure hashing entirely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized authentication verification for improved performance and more consistent timing behavior while preserving existing public configuration and exported handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->